### PR TITLE
Fixed Ranked Items Displayed Data

### DIFF
--- a/src/templates/charts.html
+++ b/src/templates/charts.html
@@ -69,30 +69,29 @@
                         var bigData = {{ warframe_data | tojson }};
                         dataLength = bigData.length;
                         var avgPrice = [];
-                        if ({{ rankedEvenLow | tojson }}) {
-                            var starter = 1;
-                        } else {
-                            var starter = 0;
-                        }
+                        var starter = 0;
                         console.log(bigData.length)
-                        for (var i = starter; i < dataLength; i += 2) {
-                            ohlc.push([
-                                bigData[i][0], // the date
-                                bigData[i][1], // open
-                                bigData[i][2], // high
-                                bigData[i][3], // low
-                                bigData[i][4] // close
-                            ]);
+                        for (var i = starter; i < dataLength; i += 1) {
+                            // if mod rank is maxed
+                            if (bigData[i][7] > 0) {
+                                ohlc.push([
+                                    bigData[i][0], // the date
+                                    bigData[i][1], // open
+                                    bigData[i][2], // high
+                                    bigData[i][3], // low
+                                    bigData[i][4] // close
+                                ]);
 
-                            volume.push([
-                                bigData[i][0], // the date
-                                bigData[i][5] // the volume
-                            ]);
+                                volume.push([
+                                    bigData[i][0], // the date
+                                    bigData[i][5] // the volume
+                                ]);
 
-                            avgPrice.push([
-                                bigData[i][0], // the date
-                                bigData[i][6] // the avg price
-                            ]);
+                                avgPrice.push([
+                                    bigData[i][0], // the date
+                                    bigData[i][6] // the avg price
+                                ]);
+                            }
                         }
                         // create the chart
                         Highcharts.stockChart('container', {
@@ -324,29 +323,28 @@
                     var bigData = {{ warframe_data | tojson }};
                     dataLength = bigData.length;
                     var avgPrice = [];
-                    if ({{ rankedEvenLow | tojson }}) {
-                        var starter = 1;
-                    } else {
-                        var starter = 0;
-                    }
-                    for (var i = starter; i < dataLength; i += 2) {
-                        ohlc.push([
-                            bigData[i][0], // the date
-                            bigData[i][1], // open
-                            bigData[i][2], // high
-                            bigData[i][3], // low
-                            bigData[i][4] // close
-                        ]);
+                    var starter = 0;
+                    for (var i = starter; i < dataLength; i += 1) {
+                        // if mod rank is maxed
+                        if (bigData[i][7] > 0) {
+                            ohlc.push([
+                                bigData[i][0], // the date
+                                bigData[i][1], // open
+                                bigData[i][2], // high
+                                bigData[i][3], // low
+                                bigData[i][4] // close
+                            ]);
 
-                        volume.push([
-                            bigData[i][0], // the date
-                            bigData[i][5] // the volume
-                        ]);
+                            volume.push([
+                                bigData[i][0], // the date
+                                bigData[i][5] // the volume
+                            ]);
 
-                        avgPrice.push([
-                            bigData[i][0], // the date
-                            bigData[i][6] // the avg price
-                        ]);
+                            avgPrice.push([
+                                bigData[i][0], // the date
+                                bigData[i][6] // the avg price
+                            ]);
+                        }
                     }
 
                     // create the chart
@@ -449,29 +447,28 @@
                     var bigData = {{ warframe_data | tojson }};
                     dataLength = bigData.length;
                     var avgPrice = [];
-                    if ({{ rankedEvenLow | tojson }}) {
-                        var starter = 0;
-                    } else {
-                        var starter = 1;
-                    }
-                    for (var i = starter; i < dataLength; i += 2) {
-                        ohlc.push([
-                            bigData[i][0], // the date
-                            bigData[i][1], // open
-                            bigData[i][2], // high
-                            bigData[i][3], // low
-                            bigData[i][4] // close
-                        ]);
+                    var starter = 0;
+                    for (var i = starter; i < dataLength; i += 1) {
+                        // if mod rank is 0
+                        if (bigData[i][7] == 0) {
+                            ohlc.push([
+                                bigData[i][0], // the date
+                                bigData[i][1], // open
+                                bigData[i][2], // high
+                                bigData[i][3], // low
+                                bigData[i][4] // close
+                            ]);
 
-                        volume.push([
-                            bigData[i][0], // the date
-                            bigData[i][5] // the volume
-                        ]);
+                            volume.push([
+                                bigData[i][0], // the date
+                                bigData[i][5] // the volume
+                            ]);
 
-                        avgPrice.push([
-                            bigData[i][0], // the date
-                            bigData[i][6] // the avg price
-                        ]);
+                            avgPrice.push([
+                                bigData[i][0], // the date
+                                bigData[i][6] // the avg price
+                            ]);
+                        }
                     }
 
                     // create the chart

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -104,7 +104,7 @@
 			<div class="row">
 				<div class="col-sm-2"></div>
 				<div class="col-sm-8">
-						<form class="contact1-form validate-form" action="/predict" method="POST" enctype="multipart/form-data">
+						<form style="margin:auto;" class="contact1-form validate-form" action="/predict" method="POST" enctype="multipart/form-data" >
 							<input  autocomplete="off" class="input1" type="text" name="search_items" id="search_items" placeholder="Search...">
 							<span class="shadow-input1"></span>
 							<script>

--- a/src/views.py
+++ b/src/views.py
@@ -148,31 +148,39 @@ def predict() -> str:
         return render_template("404.html")
     stats = get_stats(item_to_find)
     warframe_data = []
-    for d, o, h, l, c, v, ap in zip(
-        stats["dates"],
-        stats["open_prices"],
-        stats["max_prices"],
-        stats["min_prices"],
-        stats["closed_prices"],
-        stats["volumes"],
-        stats["avg_prices"],
-    ):
-        warframe_data.append([d, o, h, l, c, v, ap])
+    
     ranked_item = False
-    rankedEvenLow = None
     if len(stats["mod_ranks"]) > 0:
         ranked_item = True
-        rankedEvenLow = True
-        if len(stats["avg_prices"]) >= 2:
-            if stats["open_prices"][0] > stats["open_prices"][1]:
-                rankedEvenLow = False
+        for d, o, h, l, c, v, ap, mr in zip(
+            stats["dates"],
+            stats["open_prices"],
+            stats["max_prices"],
+            stats["min_prices"],
+            stats["closed_prices"],
+            stats["volumes"],
+            stats["avg_prices"],
+            stats["mod_ranks"],
+        ):
+            warframe_data.append([d, o, h, l, c, v, ap, mr])
+    else:
+        for d, o, h, l, c, v, ap in zip(
+            stats["dates"],
+            stats["open_prices"],
+            stats["max_prices"],
+            stats["min_prices"],
+            stats["closed_prices"],
+            stats["volumes"],
+            stats["avg_prices"],
+            stats["mod_ranks"],
+        ):
+            warframe_data.append([d, o, h, l, c, v, ap])
     return render_template(
         "charts.html",
         warframe_data_url=warframe_data_url,
         warframe_data=warframe_data,
         item_name=item_to_find.title(),
         items=item_names,
-        rankedEvenLow=rankedEvenLow,
         ranked_item=ranked_item,
     )
 


### PR DESCRIPTION
Fixed the issue where ranked items data was not properly displaying when selecting rank 0 and max rank. Sometimes rank 0 sales would show up in the max rank display and vice-versa. This PR should fix that issue. Also attempted to fix the styling of the search bar for mobile.

Should fix #1.